### PR TITLE
Support iteration over all possible values of an atom type

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ assert(bw_t::from_string("black") == "black"_a);
 assert(bw_t::from_string("pink") == std::nullopt);
 ```
 
+## Reflection
+
+You can access the list of keys of an atom type with `atom::keys`. The static
+member is a sorted array of `string_view`.
+
+```cpp
+assert(bw_t::keys.size() == 2);
+assert(bw_t::keys[0] == "black"sv);
+assert(bw_t::keys[1] == "white"sv);
+```
+
+To enumerate the atoms instead of the keys, call `atom::iota()`. It returns a
+view (as in `ranges::view`) of the type's atoms (in the sorted order).
+
+```cpp
+for (bw_t a: bw_t::iota())
+    assert(a == "black"_a || a == "white"_a);
+```
+
 ## Subtyping
 
 You can assign an atom type to another as long as the set of atoms in the former

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ assert(bw_t::keys[0] == "black"sv);
 assert(bw_t::keys[1] == "white"sv);
 ```
 
-To enumerate the atoms instead of the keys, call `atom::iota()`. It returns a
-view (as in `ranges::view`) of the type's atoms (in the sorted order).
+To enumerate atoms instead of keys, call `atom::iota()`. It returns a view (as
+in `ranges::view`) of the type's atoms (in the sorted order).
 
 ```cpp
 for (bw_t a: bw_t::iota())

--- a/include/avakar/atom.h
+++ b/include/avakar/atom.h
@@ -77,7 +77,59 @@ struct atom
 
 	friend constexpr auto operator<=>(atom lhs, atom rhs) noexcept = default;
 
+	static constexpr auto all() noexcept
+	{
+		return _all_range();
+	}
+
 private:
+	struct _all_iterator
+	{
+		using difference_type = std::ptrdiff_t;
+		using value_type = atom;
+
+		constexpr _all_iterator() noexcept = default;
+
+		constexpr _all_iterator(std::size_t v) noexcept
+			: _v(v)
+		{
+		}
+
+		constexpr atom operator*() const noexcept
+		{
+			return atom((atom::value_type)_v);
+		}
+
+		constexpr _all_iterator & operator++() noexcept
+		{
+			++_v;
+			return *this;
+		}
+
+		constexpr _all_iterator operator++(int) noexcept
+		{
+			return _all_iterator(_v++);
+		}
+
+		friend constexpr auto operator<=>(_all_iterator const &, _all_iterator const &) noexcept = default;
+
+	private:
+		std::size_t _v;
+	};
+
+	struct _all_range
+	{
+		constexpr _all_iterator begin() const noexcept
+		{
+			return _all_iterator(0);
+		}
+
+		constexpr _all_iterator end() const noexcept
+		{
+			return _all_iterator(keys.size());
+		}
+	};
+
 	explicit constexpr atom(value_type v) noexcept
 		: _v(v)
 	{

--- a/include/avakar/atom.h
+++ b/include/avakar/atom.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cassert>
 #include <optional>
+#include <ranges>
 
 namespace avakar {
 
@@ -77,59 +78,15 @@ struct atom
 
 	friend constexpr auto operator<=>(atom lhs, atom rhs) noexcept = default;
 
-	static constexpr auto all() noexcept
+	static constexpr auto iota() noexcept
 	{
-		return _all_range();
+		return std::views::transform(
+			std::views::iota((std::size_t)0, keys.size()),
+			[](std::size_t idx) noexcept { return atom((value_type)idx); }
+		);
 	}
 
 private:
-	struct _all_iterator
-	{
-		using difference_type = std::ptrdiff_t;
-		using value_type = atom;
-
-		constexpr _all_iterator() noexcept = default;
-
-		constexpr _all_iterator(std::size_t v) noexcept
-			: _v(v)
-		{
-		}
-
-		constexpr atom operator*() const noexcept
-		{
-			return atom((atom::value_type)_v);
-		}
-
-		constexpr _all_iterator & operator++() noexcept
-		{
-			++_v;
-			return *this;
-		}
-
-		constexpr _all_iterator operator++(int) noexcept
-		{
-			return _all_iterator(_v++);
-		}
-
-		friend constexpr auto operator<=>(_all_iterator const &, _all_iterator const &) noexcept = default;
-
-	private:
-		std::size_t _v;
-	};
-
-	struct _all_range
-	{
-		constexpr _all_iterator begin() const noexcept
-		{
-			return _all_iterator(0);
-		}
-
-		constexpr _all_iterator end() const noexcept
-		{
-			return _all_iterator(keys.size());
-		}
-	};
-
 	explicit constexpr atom(value_type v) noexcept
 		: _v(v)
 	{

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,6 +1,9 @@
 #include <avakar/atom.h>
 #include <avakar/mutest.h>
+#include <iterator>
+#include <ranges>
 #include <type_traits>
+#include <vector>
 
 using avakar::atom;
 using namespace avakar::literals;
@@ -20,6 +23,23 @@ mutest_case("keys should be sorted")
 	chk rgb::keys[2] == "green";
 	chk rgb::keys[3] == "red";
 	chk rgb::keys[4] == "white";
+}
+
+mutest_case("atoms can be iterated over")
+{
+	std::vector<bw> all;
+	for (auto a: bw::all())
+		all.push_back(a);
+	chk all.size() == 2;
+	chk all[0] == "black"_a;
+	chk all[1] == "white"_a;
+}
+
+mutest_case("atom::all() returns a valid range")
+{
+	std::vector<rgb> all;
+	std::ranges::copy(rgb::all(), std::back_inserter(all));
+	chk all == std::vector<rgb>{"black"_a, "blue"_a, "green"_a, "red"_a, "white"_a};
 }
 
 mutest_case("successful atom::from_string")

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -28,17 +28,19 @@ mutest_case("keys should be sorted")
 mutest_case("atoms can be iterated over")
 {
 	std::vector<bw> all;
-	for (auto a: bw::all())
+	for (auto a: bw::iota())
 		all.push_back(a);
 	chk all.size() == 2;
 	chk all[0] == "black"_a;
 	chk all[1] == "white"_a;
 }
 
-mutest_case("atom::all() returns a valid range")
+mutest_case("atom::iota() returns a valid range")
 {
+	chk std::ranges::size(bw::iota()) == 2;
+
 	std::vector<rgb> all;
-	std::ranges::copy(rgb::all(), std::back_inserter(all));
+	std::ranges::copy(rgb::iota(), std::back_inserter(all));
 	chk all == std::vector<rgb>{"black"_a, "blue"_a, "green"_a, "red"_a, "white"_a};
 }
 


### PR DESCRIPTION
There's always been support for enumerating atom type keys (via `atom::keys`), but to enumerate the corresponding atoms required iterating over an index and converting to an atom with `atom::from_value`. The new `atom::iota()` static member function simplifies this process by providing a range view of all representable atoms.